### PR TITLE
Adding limit_conn to ngix_drupal_sites

### DIFF
--- a/site.yaml
+++ b/site.yaml
@@ -160,6 +160,7 @@
       nginx_drupal_sites:
         - file_name: default
           root: "{{ drupal_path }}"
+          limit_conn: None
           http:
             port: 80
           server_name: "_"


### PR DESCRIPTION
The role from pbuyle introduced a bug. limit_conn must be declared even if the value is none.
This closes issue #25
